### PR TITLE
fix: 重复的参数导致入参校验一直失败。

### DIFF
--- a/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/rqrs/ChannelUserIdRQ.java
+++ b/jeepay-payment/src/main/java/com/jeequan/jeepay/pay/rqrs/ChannelUserIdRQ.java
@@ -29,10 +29,6 @@ import javax.validation.constraints.NotBlank;
 @Data
 public class ChannelUserIdRQ extends AbstractMchAppRQ{
 
-    /** 商户号 **/
-    @NotBlank(message="商户号不能为空")
-    private String mchNo;
-
     /** 接口代码,  AUTO表示：自动获取 **/
     @NotBlank(message="接口代码不能为空")
     private String ifCode;


### PR DESCRIPTION
ChannelUserIdRQ与其父类AbstractMchAppRQ均声明了mchNo参数。